### PR TITLE
Fix handling of Delete Projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -32,7 +32,7 @@ class ProjectsController < ApplicationController
     load_project
     if @project.destroy
       up.layer.emit('project:destroyed')
-      redirect_to companies_path
+      redirect_to projects_path
     else
       redirect_to @project, alert: 'Could not delete project'
     end

--- a/app/views/projects/index.erb
+++ b/app/views/projects/index.erb
@@ -20,7 +20,7 @@
   <tbody>
     <% @projects.each do |project| %>
       <tr>
-        <td><%= link_to project.name, project, 'up-layer': 'new', 'up-dismiss-location': projects_path %></td>
+        <td><%= link_to project.name, project, 'up-layer': 'new', 'up-dismiss-event': 'project:destroyed', 'up-on-dismissed': 'up.reload(".table")' %></td>
         <td><%= project.company.name %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
The current implementation of deleting projects is to render the list of companies in the project modal. I think this is just an accidental oversight.

To correct this:

- Update the destroy controller action to redirect back to the list of projects.
- Dismiss modal on `project:destroyed`

Closes #4